### PR TITLE
Add URL to repo for non-CRAN package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,3 +34,5 @@ LazyData: true
 URL: https://github.com/sbfnk/covid19.forecasts.uk
 BugReports: https://github.com/sbfnk/covid19.forecasts.uk/issues
 RoxygenNote: 7.1.1
+Remotes:
+  ryantibs/quantgen/R-package/quantgen


### PR DESCRIPTION
Found from the failing R-universe build: https://github.com/r-universe/epiforecasts/runs/2765168164#step:3:490